### PR TITLE
Test script and various improvements to autotex interface

### DIFF
--- a/compiler/compiler.py
+++ b/compiler/compiler.py
@@ -194,7 +194,8 @@ def do_compile(source_id: str, source_etag: str,
 
     # 2. Generate the compiled files
     o_path, log_path = compile_source(source, output_format=output_format,
-                                      verbose=verbose)
+                                      verbose=verbose,
+                                      tex_tree_timestamp=source_etag)
     
     compile_status = CompilationStatus(
         status=Status.COMPLETED if o_path is not None else Status.FAILED,
@@ -245,6 +246,7 @@ def compile_source(source: SourcePackage,
                    P_dvips_flag: bool = False, dvips_layout: str = 'letter',
                    D_dvips_flag: bool = False,
                    id_for_decryption: Optional[str] = None,
+                   tex_tree_timestamp = None,
                    verbose: bool = True) \
         -> Tuple[Optional[str], Optional[str], Optional[str]]:
     """Compile a TeX source package."""
@@ -285,6 +287,8 @@ def compile_source(source: SourcePackage,
         args.append('-D')
     if id_for_decryption is not None:
         args.append(f'-d {id_for_decryption}')
+    if tex_tree_timestamp is not None:
+        args.append(f'-U {tex_tree_timestamp}')
 
     logger.debug('run image %s with args %s', image, args)
     run_docker(image, args=args,

--- a/compiler/compiler.py
+++ b/compiler/compiler.py
@@ -297,9 +297,6 @@ def compile_source(source: SourcePackage,
     # Now we have to figure out what went right or wrong.
     ext = Format(output_format).ext
 
-    # TODO: Sometimes the resuts end up in the tex_cache directory (when using pdflatex),
-    # but other times it ends up in the root source (when using ps2pdf). Eventually,
-    # this needs to be sorted out.
     cache = os.path.join(source_dir, 'tex_cache')
     try:
         # The converter image has some heuristics for naming (e.g. adding a
@@ -307,12 +304,8 @@ def compile_source(source: SourcePackage,
         # file in the format that we requested, so that's as specific as we
         # should need to be.
         cache_results = [fp for fp in os.listdir(cache) if fp.endswith(f'.{ext}')]
-        if cache_results:
-            oname = cache_results[0]
-            output_path = os.path.join(cache, oname)
-        else:
-            oname = [fp for fp in os.listdir(source_dir) if fp.endswith(f'.{ext}')][0]
-            output_path = os.path.join(source_dir, oname)
+        oname = cache_results[0]
+        output_path = os.path.join(cache, oname)
     except IndexError:  # The expected output isn't here.
         # Normally I'd prefer to raise an exception if the compilation failed,
         # but we still have work to do.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ x-base-service:
     FLASK_APP: /opt/arxiv/app.py
     FLASK_DEBUG: 1
     HOST_SOURCE_ROOT: "${HOST_SOURCE_ROOT}"
+    VERBOSE_COMPILE: 1
 
 services:
   compiler-test-redis:

--- a/test.py
+++ b/test.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime
 from itertools import chain
 import json
 import logging
@@ -13,10 +14,15 @@ def generate_arxiv_id():
     return f"{year:02d}{month:02d}.{id:05d}"
 
 def payload(id):
+    year = int(id[0:2])
+    year += 1900 if year > 90 else 2000
+    month = int(id[2:4])
+    date = datetime(year, month, 1,1,4,33)
     return {
         "source_id" : id,
         # TODO: Update with actual checksum
-        "checksum" : "\"Tue, 02 Feb 2016 01:04:33 GMT\"", 
+        #"checksum" : "\"Tue, 02 Feb 2016 01:04:33 GMT\"", 
+        "checksum" : date.timestamp(),
         "format" : "pdf",
         "force" : True
         }

--- a/test.py
+++ b/test.py
@@ -50,10 +50,14 @@ async def test_compilation(arxiv_id=None):
     elif status == 'completed':
         return (arxiv_id, True)
 
-def main(N=1):
+def main(N=1, ids=[]):
     futures = []
-    for i in range(N):
-        futures.append(asyncio.ensure_future(test_compilation()))
+    if ids:
+        for id in ids:
+            futures.append(asyncio.ensure_future(test_compilation(id)))
+    else:
+        for i in range(N):
+            futures.append(asyncio.ensure_future(test_compilation()))
 
     loop = asyncio.get_event_loop()
     result = loop.run_until_complete(asyncio.wait(futures))
@@ -62,6 +66,12 @@ def main(N=1):
         print(arxiv_id, success)
 
 if __name__ == '__main__':
-    main(N=5)
+    from argparse import ArgumentParser
 
-    # asyncio.run(main()) # TODO: Replace above block when upgraded to py37
+    parser = ArgumentParser()
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-N', type=int, default=5)
+    group.add_argument('--ids', nargs="+")
+    args = parser.parse_args()
+    
+    main(N=args.N, ids=args.ids)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,61 @@
+import asyncio
+from itertools import chain
+import json
+import logging
+import random
+import requests
+
+def generate_arxiv_id():
+    year = random.randint(9,17)
+    month = random.randint(1,12)
+    id = random.randint(1,2500)
+
+    return f"{year:02d}{month:02d}.{id:05d}"
+
+def payload(id):
+    return {
+        "source_id" : id,
+        # TODO: Update with actual checksum
+        "checksum" : "\"Tue, 02 Feb 2016 01:04:33 GMT\"", 
+        "format" : "pdf",
+        "force" : True
+        }
+
+def check_status(task_url):
+    r = requests.get(task_url)
+    print(r)
+    try:
+        data = r.json()
+        return data['status']['status']
+    except:
+        if r.status_code == 404:
+            return 'pending'
+
+async def test_compilation(arxiv_id=None):
+    """ returns (arxiv_id: str, success: Bool) """
+    if arxiv_id is None:
+        arxiv_id = generate_arxiv_id()
+    data = json.dumps(payload(arxiv_id))
+    logging.debug(f"submitting task for {arxiv_id}")
+    r = requests.post("http://localhost:8000/", data=data)
+    task_url = r.headers['Location']
+
+    status = 'in_progress'
+    while status in ['in_progress', 'pending']:
+        status = check_status(task_url)
+        print(status)
+        await asyncio.sleep(10)
+
+    if status == 'failed':
+        return (arxiv_id, False)
+    elif status == 'completed':
+        return (arxiv_id, True)
+
+async def main(N=1):
+    arxiv_id, success = await test_compilation('1601.00004')
+    print(arxiv_id, success)
+
+if __name__ == '__main__':
+    loop = asyncio.get_event_loop()
+    result = loop.run_until_complete(main())
+    # asyncio.run(main()) # TODO: Replace above block when upgraded to py37


### PR DESCRIPTION
This PR contains two primary contributions:
1. A test script, adequately called `test.py` with a CLI for either testing random arxiv papers or for testing specific IDs using the compiler service.
2. Various patches for the arxiv-compiler service:
  - source_etag now bears a timestamp to pass to the autotex system to tell it which texlive environment to use.
  - compilation products are searched in the tex_cache directory only
  - verbose compilation is enabled by default to help with debugging